### PR TITLE
Add page counter

### DIFF
--- a/Wiretap.body.php
+++ b/Wiretap.body.php
@@ -107,7 +107,7 @@ class Wiretap {
 		global $wgDBprefix;
 
 		$wiretapTable = $wgDBprefix . 'wiretap';
-		$wiretapCounterTable = $wgDBprefix . 'wiretap_counter';
+		$wiretapCounterTable = $wgDBprefix . 'wiretap_counter_period';
 		$schemaDir = __DIR__ . '/schema';
 		
 		$updater->addExtensionTable(

--- a/Wiretap.body.php
+++ b/Wiretap.body.php
@@ -64,6 +64,7 @@ class Wiretap {
 		global $wgDBprefix;
 
 		$wiretapTable = $wgDBprefix . 'wiretap';
+		$wiretapCounterTable = $wgDBprefix . 'wiretap_counter';
 		$schemaDir = __DIR__ . '/schema';
 		
 		$updater->addExtensionTable(
@@ -75,7 +76,11 @@ class Wiretap {
 			'response_time',
 			"$schemaDir/patch-1-response-time.sql"
 		);
-
+		$updater->addExtensionTable(
+			$wiretapCounterTable,
+			"$schemaDir/patch-2-page-counter.sql"
+		);
+		
 		return true;
 	}
 	

--- a/Wiretap.body.php
+++ b/Wiretap.body.php
@@ -57,7 +57,50 @@ class Wiretap {
 			$egWiretapCurrentHit,
 			__METHOD__
 		);
+
+		global $egWiretapAddToPeriodCounter, $egWiretapAddToAlltimeCounter;
+
+		if ( $egWiretapAddToAlltimeCounter ) {
+			self::upsertHit( $egWiretapCurrentHit['page_id'], 'all' );
+		}
+		
+		if ( $egWiretapAddToPeriodCounter ) {
+			self::upsertHit( $egWiretapCurrentHit['page_id'], 'period' );
+		}
+
 		return true;
+	}
+
+	public static function upsertHit ( $pageId, $type='all' ) {
+
+		if ( $type === 'period' ) {
+			$table = 'wiretap_counter_period';
+		}
+		else if ( $type === 'all' ) {
+			$table = 'wiretap_counter_alltime';
+		}
+		else return;
+
+		$dbw = wfGetDB( DB_MASTER );
+		$dbw->upsert(
+			$table,
+			array(
+				'page_id' => $pageId,
+				'count' => 1,
+				'count_unique' => 1,
+			),
+			array( 'page_id' ),
+			array(
+				'count = count + 1',
+				// does not guess this is a new unique hit
+				// need to run maint script for that
+				// 'count_unique = count_unique + 1',
+			),
+			__METHOD__ 
+		);
+
+		return;
+
 	}
 
 	public static function updateDatabase( DatabaseUpdater $updater ) {

--- a/Wiretap.php
+++ b/Wiretap.php
@@ -97,3 +97,14 @@ $wgResourceModules += array(
 	),
 
 );
+
+
+// for selecting a short period over which to count hits to pages
+// set to 1 to count over the last day, 4 over the last 4 days, etc
+$egWiretapCounterPeriod = 30;
+
+// use the all-time counter by default
+$egWiretapAddToAlltimeCounter = true;
+
+// don't use the period counter by default
+$egWiretapAddToPeriodCounter = false;

--- a/schema/patch-2-page-counter.sql
+++ b/schema/patch-2-page-counter.sql
@@ -1,10 +1,13 @@
-CREATE TABLE IF NOT EXISTS /*_*/wiretap_counter (
-	page_id            INT(8) UNSIGNED NOT NULL,
-	counter_hour       INT(8) UNSIGNED NOT NULL DEFAULT 0,
-	counter_prev_hour  INT(8) UNSIGNED NOT NULL DEFAULT 0,
-	counter_day        INT(8) UNSIGNED NOT NULL DEFAULT 0,
-	counter_prev_day   INT(8) UNSIGNED NOT NULL DEFAULT 0,
-	counter_week       INT(8) UNSIGNED NOT NULL DEFAULT 0,
-	counter_month      INT(8) UNSIGNED NOT NULL DEFAULT 0,
-	counter_all_time   INT(8) UNSIGNED NOT NULL DEFAULT 0
+CREATE TABLE IF NOT EXISTS /*_*/wiretap_counter_period (
+	page_id        INT(8) UNSIGNED NOT NULL,
+
+	count          INT(8) UNSIGNED NOT NULL DEFAULT 0,
+	count_unique   INT(8) UNSIGNED NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS /*_*/wiretap_counter_alltime (
+	page_id        INT(8) UNSIGNED NOT NULL,
+
+	count          INT(8) UNSIGNED NOT NULL DEFAULT 0,
+	count_unique   INT(8) UNSIGNED NOT NULL DEFAULT 0
 );

--- a/schema/patch-2-page-counter.sql
+++ b/schema/patch-2-page-counter.sql
@@ -3,7 +3,8 @@ CREATE TABLE IF NOT EXISTS /*_*/wiretap_counter_period (
 
 	count          INT(8) UNSIGNED NOT NULL DEFAULT 0,
 	count_unique   INT(8) UNSIGNED NOT NULL DEFAULT 0
-);
+) /*$wgDBTableOptions*/;
+CREATE UNIQUE INDEX /*i*/wiretap_counter_period_page_id ON /*_*/wiretap_counter_period (page_id);
 
 CREATE TABLE IF NOT EXISTS /*_*/wiretap_counter_alltime (
 	page_id        INT(8) UNSIGNED NOT NULL,
@@ -11,3 +12,4 @@ CREATE TABLE IF NOT EXISTS /*_*/wiretap_counter_alltime (
 	count          INT(8) UNSIGNED NOT NULL DEFAULT 0,
 	count_unique   INT(8) UNSIGNED NOT NULL DEFAULT 0
 );
+CREATE UNIQUE INDEX /*i*/wiretap_counter_alltime_page_id ON /*_*/wiretap_counter_alltime (page_id);

--- a/schema/patch-2-page-counter.sql
+++ b/schema/patch-2-page-counter.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS /*_*/wiretap_counter (
+	page_id            INT(8) UNSIGNED NOT NULL,
+	counter_hour       INT(8) UNSIGNED NOT NULL DEFAULT 0,
+	counter_prev_hour  INT(8) UNSIGNED NOT NULL DEFAULT 0,
+	counter_day        INT(8) UNSIGNED NOT NULL DEFAULT 0,
+	counter_prev_day   INT(8) UNSIGNED NOT NULL DEFAULT 0,
+	counter_week       INT(8) UNSIGNED NOT NULL DEFAULT 0,
+	counter_month      INT(8) UNSIGNED NOT NULL DEFAULT 0,
+	counter_all_time   INT(8) UNSIGNED NOT NULL DEFAULT 0
+);

--- a/wiretapRecordPageHitCount.php
+++ b/wiretapRecordPageHitCount.php
@@ -58,7 +58,6 @@ class WiretapRecordPageHitCount extends Maintenance {
 			$this->output( "\n \"type\" option must be set to either \"all\" or \"period\". \n" );
 		}
 
-		$egWiretapCounterPeriod = 1000;
 		date_default_timezone_set("UTC"); 
 		$ts = new MWTimestamp( date( 'YmdHis', strtotime( "now - $egWiretapCounterPeriod days" ) ) );
 
@@ -73,23 +72,6 @@ class WiretapRecordPageHitCount extends Maintenance {
 		}
 
 		$dbw = wfGetDB( DB_MASTER );
-
-		// get recent hits
-		// $res = $dbr->select(
-		// 	array('w' => 'wiretap'),
-		// 	array(
-		// 		"w.page_id", 
-		// 		"COUNT(*) AS total_hits",
-		// 		"COUNT( DISTINCT user_name ) as unique_hits",
-		// 	),
-		// 	$readConditions,
-		// 	__METHOD__,
-		// 	array(
-		// 		"GROUP BY" => "w.page_id",
-		// 		"ORDER BY" => "w.page_id ASC",
-		// 	),
-		// 	null // join conditions
-		// );
 
 		// clear the table
 		$res = $dbw->delete(
@@ -116,16 +98,6 @@ class WiretapRecordPageHitCount extends Maintenance {
 				"ORDER BY" => "page_id ASC",
 			) 
 		);
-
-		# Perform replace
-		# Note that multi-row replace is very efficient for MySQL but may be inefficient for
-		# some other DBMSes, mostly due to poor simulation by us
-		// $dbw->replace(
-		// 	'wiretap_counter',
-		// 	array( array( 'page_id', 'count', 'wl_title' ) ),
-		// 	$values,
-		// 	__METHOD__
-		// );
 
 		$this->output( "\n Finished recording page traffic. \n" );
 	}

--- a/wiretapRecordPageHitCount.php
+++ b/wiretapRecordPageHitCount.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This script records the number of hits each page in the wiki has
+ * recieved in the last day/week/month/all-time.
+ *
+ * Usage:
+ *  no parameters @todo: add a --quick parameter (to not do a full caluculation but make a best-guess)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * http://www.gnu.org/copyleft/gpl.html
+ *
+ * @author James Montalvo
+ * @ingroup Maintenance
+ */
+
+// @todo: does this always work if extensions are not in $IP/extensions ??
+// this was what was done by SMW
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../..';
+require_once $basePath . '/maintenance/Maintenance.php';
+
+class WiretapRecordPageHitCount extends Maintenance {
+	
+	public function __construct() {
+		parent::__construct();
+		
+		$this->mDescription = "Count the recent hits for each page.";
+	}
+	
+	public function execute() {
+		$recorder = new WatchStateRecorder();
+		$recorder->recordAll();
+
+		if ( $quick ) {
+
+		}
+		else {
+
+			SELECT 
+
+			FROM wiretap
+
+		}
+
+
+		$this->output( "\n Finished recording page traffic. \n" );
+	}
+}
+
+$maintClass = "WatchAnalyticsRecordState";
+require_once( DO_MAINTENANCE );


### PR DESCRIPTION
Adds two tables for counting number of hits to pages:

* wiretap_counter_alltime: counts the all-time number of hits to each page
* wiretap_counter_period: counts the number of hits to each page over a given time period (between X days ago and present). This is configurable with ```$egWiretapCounterPeriod = X;```

On each page load either or both of these counters can be updated by setting these two variables:

* ```$egWiretapAddToAlltimeCounter``` = true; // defaults to true
* ```$egWiretapAddToPeriodCounter``` = true; // defaults to false

```$egWiretapAddToPeriodCounter``` defaults to false because the "period" table requires the use of the ```wiretapRecordPageHitCount.php``` maintenance script to periodically clear out the table and refresh it with data from the wiretap table. Without this refresh (which should be done fairly regularly via a cron job) the period-table data gets out of date.

Additionally, both tables have a ```count_unique``` field that counts how many unique hits each page has gotten. This is also only provided by the maintenance script.
