### PR TITLE
Don't record bad hits (probably API hits)

### DIFF
--- a/Wiretap.body.php
+++ b/Wiretap.body.php
@@ -48,6 +48,10 @@ class Wiretap {
 	public static function recordInDatabase (  ) { // could have param &$output
 		global $wgRequestTime, $egWiretapCurrentHit;
 
+		if ( ! isset( $wgRequestTime ) || ! isset( $wgRequestTime['page_id'] ) ) {
+			return true; // for whatever reason the poorly-named "updateTable" method was not called; abort.
+		}
+
 		// calculate response time now, in the last hook (that I know of).
 		$egWiretapCurrentHit['response_time'] = round( ( microtime( true ) - $wgRequestTime ) * 1000 );
 		


### PR DESCRIPTION
Stops wiretap from recording a hit if the initial recording of page_id, username, timestamp, etc were not recorded. This happens probably on API hits, but could be on other hits where the "BeforeInitialize" hook is not run