### PR TITLE
Support features from MW legacy page_counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,22 @@ MediaWiki extension for user pageview tracking.
 
 1. Obtain the code from [GitHub](https://github.com/enterprisemediawiki/Wiretap)
 2. Extract the files in a directory called ``Wiretap`` in your ``extensions/`` folder.
-3. Add the following code at the bottom of your "LocalSettings.php" file:  
-  ``require_once "$IP/extensions/Wiretap/Wiretap.php";``
-4. Go to "Special:Version" on your wiki to verify that the extension is successfully installed.
-5. Done.
+3. Add the following code at the bottom of your "LocalSettings.php" file: `require_once "$IP/extensions/Wiretap/Wiretap.php";`
+4. In the command line run `php maintenance/update.php`
+5. Go to "Special:Version" on your wiki to verify that the extension is successfully installed.
+6. Done.
+
+## Upgrading
+
+If upgrading, make sure to run `php maintenance/update.php` as well as `php extensions/Wiretap/wiretapRecordPageHitCount.php --type=all`. This will create a hit-totals count for all pages in your wiki.
+
+### Before upgrading to MediaWiki 1.25
+
+Before upgrading your instalation to MediaWiki 1.25, make sure to grab the latest Wiretap and in addition to running update.php and wiretapRecordPageHitCount.php, also run:
+
+```
+php extensions/Wiretap/wiretapRecordLegacyHitCount.php
+```
 
 ## Important note
 

--- a/Wiretap.body.php
+++ b/Wiretap.body.php
@@ -203,10 +203,10 @@ class Wiretap {
 			$viewcount = Wiretap::getCount( $skin->getTitle() );
 			if ( $viewcount ) {
 				wfDebugLog(
-					"HitCounters",
+					"Wiretap",
 					"Got viewcount=$viewcount and putting in page"
 				);
-				$tpl->set( 'viewcount', $skin->msg( 'viewcount' )->
+				$tpl->set( 'viewcount', $skin->msg( 'wiretapviewcount' )->
 					numParams( $viewcount )->parse() );
 			}
 		}
@@ -217,11 +217,11 @@ class Wiretap {
 		$dbr = wfGetDB( DB_SLAVE );
 		$result = $dbr->select(
 			array( 'w' => 'wiretap_counter_alltime', 'leg' => 'wiretap_legacy' ),
-			array( 'total_count' => 'legacy_count + w.count' ),
+			array( 'total_count' => 'IFNULL( legacy_count, 0 )  + IFNULL( w.count, 0 )' ),
 			array( 'w.page_id' => $title->getArticleID() ),
 			__METHOD__,
 			null,
-			array( 'wiretap_legacy' => array( 'LEFT JOIN', 'legacy_id=page_id' ) )
+			array( 'wiretap_legacy' => array( 'LEFT JOIN', 'leg.legacy_id=w.page_id' ) )
 		);
 
 		$page = $result->fetchObject();

--- a/Wiretap.php
+++ b/Wiretap.php
@@ -31,6 +31,9 @@ $wgHooks['BeforeInitialize'][] = 'Wiretap::updateTable';
 // record the length of time required to build the page.
 $wgHooks['AfterFinalPageOutput'][] = 'Wiretap::recordInDatabase';
 
+// Add wiretap view counter to bottom of page
+$wgHooks['SkinTemplateOutputPageBeforeExec'][] = 'Wiretap::onSkinTemplateOutputPageBeforeExec';
+
 // update database (using maintenance/update.php)
 $wgHooks['LoadExtensionSchemaUpdates'][] = 'Wiretap::updateDatabase';
 

--- a/Wiretap.php
+++ b/Wiretap.php
@@ -111,3 +111,6 @@ $egWiretapAddToAlltimeCounter = true;
 
 // don't use the period counter by default
 $egWiretapAddToPeriodCounter = false;
+
+// of course we want counters! why else have the extension!
+$wgDisableCounters = false;

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -11,5 +11,6 @@
 	"wiretap-filterpage": "filter",
 	"wiretap-unfilter": "Unfilter",
 	"wiretap-rawdata": "Data",
-	"wiretap-chart": "Chart"
+	"wiretap-chart": "Chart",
+	"wiretap-viewcount": "This page has been viewed $1 {{PLURAL:$1|time|times}} ($2 via redirect)"
 }

--- a/schema/patch-3-legacy-counter.sql
+++ b/schema/patch-3-legacy-counter.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS /*_*/wiretap_legacy (
+	legacy_id        INT(8) UNSIGNED NOT NULL,
+	legacy_counter   INT(8) UNSIGNED NOT NULL DEFAULT 0
+) /*$wgDBTableOptions*/;
+CREATE UNIQUE INDEX /*i*/wiretap_counter_legacy_page_id ON /*_*/wiretap_legacy (legacy_id);

--- a/wiretapRecordLegacyHitCount.php
+++ b/wiretapRecordLegacyHitCount.php
@@ -92,6 +92,9 @@ class WiretapRecordLegacyHitCount extends Maintenance {
 
 		$arrayForDatabase = array();
 		foreach( $legacyCounter as $id => $count ) {
+			if ( $count == 0 ) {
+				continue; // don't bother recording pages that have zero hits
+			}
 			$arrayForDatabase[] = array(
 				'legacy_id' => $id,
 				'legacy_counter' => $count

--- a/wiretapRecordLegacyHitCount.php
+++ b/wiretapRecordLegacyHitCount.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * This script records the number of hits each page in the wiki had in the
+ * legacy hit counter (pre MW 1.25) in the `page` table in the `page_counter`
+ * column **prior** to the installation of Wiretap. This record may not be
+ * perfect, since Wiretap and the legacy page counter counted pages slightly
+ * differently. One major difference is that all views of redirect pages are
+ * attributed to their target pages.
+ *
+ * Usage:
+ *  --type: whether to record all time or hits in a period
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * http://www.gnu.org/copyleft/gpl.html
+ *
+ * @author James Montalvo
+ * @ingroup Maintenance
+ */
+
+// @todo: does this always work if extensions are not in $IP/extensions ??
+// this was what was done by SMW
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../..';
+require_once $basePath . '/maintenance/Maintenance.php';
+
+class WiretapRecordLegacyHitCount extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+
+		$this->mDescription = "Count the legacy hits for each page.";
+
+	}
+
+	public function execute() {
+
+		$dbw = wfGetDB( DB_MASTER );
+
+		if ( ! $dbw->fieldExists( 'page', 'page_counter', __METHOD__ ) ) {
+			$this->output(
+				"\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *"
+				"\n* The `page` table does not have a field `page_counter`.  *" .
+				"\n* This means you have upgraded to MW 1.25 or beyond.      *" .
+				"\n* You can no longer record legacy view totals.            *" .
+				"\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n"
+			);
+			return false;
+		}
+
+		// clear the table
+		$res = $dbw->delete(
+			'wiretap_legacy',
+			null, // conditions = none; delete everything
+			__METHOD__
+		);
+
+		// get actual pages (non-redirects)
+		$targetPages = $dbw->query( $this->getLegacyPageCounterQuery( false ) );
+
+		$legacyCounter = array();
+		while( $p = $targetPages->fetchObject() ) {
+			$legacyCounter[ $p->id ] = $p->pre_wiretap_count;
+		}
+		unset( $targetPages );
+
+		// get redirects
+		$redirects = $dbw->query( $this->getLegacyPageCounterQuery( true ) );
+
+
+		while( $r = $redirects->fetchObject() ) {
+
+			// get the target page ID of this redirect. The function below will follow
+			// multiple redirects to the final target (hopefully there are no circular
+			// redirects!)
+			$targetPageID = self::getRedirectTargetID( $r->id );
+
+			// add this redirect's pre_wiretap_count to the target pages
+			$legacyCounter[ $targetPageID ] += $r->pre_wiretap_count;
+		}
+
+		$arrayForDatabase = array();
+		foreach( $legacyCounter as $id => $count ) {
+			$arrayForDatabase[] = array(
+				'legacy_id' => $id,
+				'legacy_counter' => $count
+			);
+		}
+		unset( $legacyCounter );
+
+		$success = $dbw->insert(
+			'wiretap_legacy',
+			$arrayForDatabase,
+			__METHOD__
+		);
+
+		if ( $success ) {
+			$numPages = $dbw->affectedRows();
+			$this->output( "\n Legacy page views recorded for $numPages pages. \n" );
+
+		}
+		else {
+			$this->output( "\n Failure to insert rows \n" );
+		}
+
+	}
+
+	static protected function getRedirectTargetID ( $id ) {
+		$redirect = WikiPage::newFromID( $id );
+		if ( ! $redirect ) {
+			return 0;
+		}
+		$target = $redirect->getRedirectTarget();
+		if ( ! $target ) {
+			return 0;
+		}
+
+		if ( $target->isRedirect() ) {
+			return self::getRedirectTargetID( $target->getArticleID() );
+		}
+
+		return $target->getArticleID();
+	}
+
+	protected function getLegacyPageCounterQuery ( $redirects=false ) {
+
+		if ( $redirects ) {
+			$redirects = '1';
+		}
+		else {
+			$redirects = '0';
+		}
+
+		$query =
+			"SELECT
+			    p.page_id AS id,
+			    IFNULL( p.page_counter, 0 ) - IFNULL( tmp.wiretap_counter, 0 ) AS pre_wiretap_count
+			FROM page AS p
+			JOIN (
+			    SELECT
+			        wiretap.page_id,
+			        COUNT(*) AS wiretap_counter
+			    FROM wiretap
+			    WHERE
+				 	page_id > 0
+					AND page_action IS NULL
+			    GROUP BY page_id
+			) AS tmp ON p.page_id = tmp.page_id
+			WHERE
+				p.page_is_redirect = $redirects";
+
+	}
+}
+
+$maintClass = "WiretapRecordLegacyHitCount";
+require_once( DO_MAINTENANCE );

--- a/wiretapRecordLegacyHitCount.php
+++ b/wiretapRecordLegacyHitCount.php
@@ -46,11 +46,13 @@ class WiretapRecordLegacyHitCount extends Maintenance {
 
 	public function execute() {
 
+		$this->output( "\nStarting building legacy hit counts" );
+
 		$dbw = wfGetDB( DB_MASTER );
 
 		if ( ! $dbw->fieldExists( 'page', 'page_counter', __METHOD__ ) ) {
 			$this->output(
-				"\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *"
+				"\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *" .
 				"\n* The `page` table does not have a field `page_counter`.  *" .
 				"\n* This means you have upgraded to MW 1.25 or beyond.      *" .
 				"\n* You can no longer record legacy view totals.            *" .
@@ -60,13 +62,15 @@ class WiretapRecordLegacyHitCount extends Maintenance {
 		}
 
 		// clear the table
+		$this->output( "\nDeleting existing legacy hit count" );
 		$res = $dbw->delete(
 			'wiretap_legacy',
-			null, // conditions = none; delete everything
+			array( 'legacy_id != -1'), // delete everything, MW won't allow this to be blank
 			__METHOD__
 		);
 
 		// get actual pages (non-redirects)
+		$this->output( "\nRetrieving non-redirect page info" );
 		$targetPages = $dbw->query( $this->getLegacyPageCounterQuery( false ) );
 
 		$legacyCounter = array();
@@ -76,9 +80,11 @@ class WiretapRecordLegacyHitCount extends Maintenance {
 		unset( $targetPages );
 
 		// get redirects
+		$this->output( "\nRetrieving redirect page info" );
 		$redirects = $dbw->query( $this->getLegacyPageCounterQuery( true ) );
 
 
+		$this->output( "\nAdding redirect hits to target pages" );
 		while( $r = $redirects->fetchObject() ) {
 
 			// get the target page ID of this redirect. The function below will follow
@@ -87,13 +93,29 @@ class WiretapRecordLegacyHitCount extends Maintenance {
 			$targetPageID = self::getRedirectTargetID( $r->id );
 
 			// add this redirect's pre_wiretap_count to the target pages
-			$legacyCounter[ $targetPageID ] += $r->pre_wiretap_count;
+			if ( isset( $legacyCounter[ $targetPageID ] ) ) {
+				$legacyCounter[ $targetPageID ] += $r->pre_wiretap_count;
+			}
+			else {
+				$legacyCounter[ $targetPageID ] = $r->pre_wiretap_count;
+			}
+
 		}
 
 		$arrayForDatabase = array();
+		$this->output( "\nConstructing data for reinsertion into database" );
 		foreach( $legacyCounter as $id => $count ) {
-			if ( $count == 0 ) {
-				continue; // don't bother recording pages that have zero hits
+
+			// Don't bother recording pages that have less than one hit
+			// Wiretap records hits differently...there are going to be some
+			// inconsistencies, but we're not going to subtract views from
+			// those Wiretap is declaring happened.
+			if ( $count < 1 ) {
+				continue;
+			}
+			// Only show real pages
+			if ( $id == 0 ) {
+				continue;
 			}
 			$arrayForDatabase[] = array(
 				'legacy_id' => $id,
@@ -102,6 +124,7 @@ class WiretapRecordLegacyHitCount extends Maintenance {
 		}
 		unset( $legacyCounter );
 
+		$this->output( "\nInserting rows into database" );
 		$success = $dbw->insert(
 			'wiretap_legacy',
 			$arrayForDatabase,
@@ -110,11 +133,11 @@ class WiretapRecordLegacyHitCount extends Maintenance {
 
 		if ( $success ) {
 			$numPages = $dbw->affectedRows();
-			$this->output( "\n Legacy page views recorded for $numPages pages. \n" );
+			$this->output( "\n\nLegacy page views recorded for $numPages pages. \n" );
 
 		}
 		else {
-			$this->output( "\n Failure to insert rows \n" );
+			$this->output( "\n\nFailure to insert rows \n" );
 		}
 
 	}
@@ -145,12 +168,12 @@ class WiretapRecordLegacyHitCount extends Maintenance {
 			$redirects = '0';
 		}
 
-		$query =
+		return
 			"SELECT
 			    p.page_id AS id,
 			    IFNULL( p.page_counter, 0 ) - IFNULL( tmp.wiretap_counter, 0 ) AS pre_wiretap_count
 			FROM page AS p
-			JOIN (
+			LEFT JOIN (
 			    SELECT
 			        wiretap.page_id,
 			        COUNT(*) AS wiretap_counter


### PR DESCRIPTION
Add support for MW's legacy page_counter. Added `wiretapRecordLegacyHitCount.php` script, which when run on a pre-MW-1.25 wiki will calculate the number of hits to each page prior to the existence of Extension:Wiretap on that wiki. Thus, that data is not lost when the page_counter goes away in MW 1.25.

Additionally, added the "this page has been viewed X times" message to the bottom of each page, which uses the legacy number plus the Wiretap number. The wiretap number has the benefit of being able to distinguish between direct page views and redirected page views, and the message states this difference. Note that legacy page views are all assumed to be to the target (non-redirect) page.