### PR TITLE
Bugfix17 use linker

### DIFF
--- a/SpecialWiretap.php
+++ b/SpecialWiretap.php
@@ -1,7 +1,4 @@
 <?php
-// for LinkRenderer
-use MediaWiki\MediaWikiServices;
-
 class SpecialWiretap extends SpecialPage {
 
 	public $mMode;
@@ -527,8 +524,7 @@ class WiretapPager extends ReverseChronologicalPager {
 		if ( ! $pageTitle )
 			$page = $row->page_name; // if somehow still no page, just show text
 		else {
-			$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
-			$page = $linkRenderer->makeLink( $pageTitle );
+			$page = Linker::link( $pageTitle );
 		}
 
 		if ( $this->filterPage ) {
@@ -549,7 +545,7 @@ class WiretapPager extends ReverseChronologicalPager {
 
 		if ( $row->referer_title ) {
 			$referer = Title::newFromText( $row->referer_title );
-			$referer = $linkRenderer->makeLink( $referer );
+			$referer = Linker::link( $referer );
 		}
 		else
 			$referer = '';

--- a/SpecialWiretap.php
+++ b/SpecialWiretap.php
@@ -1,4 +1,6 @@
 <?php
+// for LinkRenderer
+use MediaWiki\MediaWikiServices;
 
 class SpecialWiretap extends SpecialPage {
 
@@ -524,9 +526,10 @@ class WiretapPager extends ReverseChronologicalPager {
 
 		if ( ! $pageTitle )
 			$page = $row->page_name; // if somehow still no page, just show text
-		else
-			$page = $this->getSkin()->link( $pageTitle );
-
+		else {
+			$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
+			$page = $linkRenderer->makeLink( $pageTitle );
+		}
 
 		if ( $this->filterPage ) {
 			// do nothing for now...
@@ -546,7 +549,7 @@ class WiretapPager extends ReverseChronologicalPager {
 
 		if ( $row->referer_title ) {
 			$referer = Title::newFromText( $row->referer_title );
-			$referer = $this->getSkin()->link( $referer );
+			$referer = $linkRenderer->makeLink( $referer );
 		}
 		else
 			$referer = '';


### PR DESCRIPTION
This fix uses the Linker::link() method that is available in both REL1_27 and REL1_28 so it's compatible with both versions. Fixes Issue #17 Tested on [REL1_28](https://freephile.qualitybox.us/wiki/Special:Wiretap)