### PR TITLE
Handle read-only state of MW

### DIFF
--- a/Wiretap.body.php
+++ b/Wiretap.body.php
@@ -47,9 +47,9 @@ class Wiretap {
 	}
 
 	public static function recordInDatabase (  ) { // could have param &$output
-		global $wgRequestTime, $egWiretapCurrentHit;
+		global $wgRequestTime, $egWiretapCurrentHit, $wgReadOnly;
 
-		if ( ! isset( $egWiretapCurrentHit ) || ! isset( $egWiretapCurrentHit['page_id'] ) ) {
+		if ( $wgReadOnly || ! isset( $egWiretapCurrentHit ) || ! isset( $egWiretapCurrentHit['page_id'] ) ) {
 			return true; // for whatever reason the poorly-named "updateTable" method was not called; abort.
 		}
 


### PR DESCRIPTION
Prior to this, Wiretap would cause every page visit to result in in a DB error (instead of actual wiki content) when the admin set `$wgReadOnly`.