### PR TITLE
Fix Index Conflict

### DIFF
--- a/schema/patch-2-page-counter.sql
+++ b/schema/patch-2-page-counter.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS /*_*/wiretap_counter_period (
 	count          INT(8) UNSIGNED NOT NULL DEFAULT 0,
 	count_unique   INT(8) UNSIGNED NOT NULL DEFAULT 0
 ) /*$wgDBTableOptions*/;
+DROP INDEX /*i*/wiretap_counter_period_page_id ON /*_*/wiretap_counter_period;
 CREATE UNIQUE INDEX /*i*/wiretap_counter_period_page_id ON /*_*/wiretap_counter_period (page_id);
 
 CREATE TABLE IF NOT EXISTS /*_*/wiretap_counter_alltime (
@@ -12,4 +13,5 @@ CREATE TABLE IF NOT EXISTS /*_*/wiretap_counter_alltime (
 	count          INT(8) UNSIGNED NOT NULL DEFAULT 0,
 	count_unique   INT(8) UNSIGNED NOT NULL DEFAULT 0
 );
+DROP INDEX /*i*/wiretap_counter_alltime_page_id ON /*_*/wiretap_counter_alltime;
 CREATE UNIQUE INDEX /*i*/wiretap_counter_alltime_page_id ON /*_*/wiretap_counter_alltime (page_id);

--- a/schema/patch-3-legacy-counter.sql
+++ b/schema/patch-3-legacy-counter.sql
@@ -2,4 +2,5 @@ CREATE TABLE IF NOT EXISTS /*_*/wiretap_legacy (
 	legacy_id        INT(8) UNSIGNED NOT NULL,
 	legacy_counter   INT(8) UNSIGNED NOT NULL DEFAULT 0
 ) /*$wgDBTableOptions*/;
+DROP INDEX /*i*/wiretap_counter_legacy_page_id ON /*_*/wiretap_legacy;
 CREATE UNIQUE INDEX /*i*/wiretap_counter_legacy_page_id ON /*_*/wiretap_legacy (legacy_id);


### PR DESCRIPTION
When upgrading Wiretap, you will get an error when it tries
to create the unique indexex that already exist. So, we
delete the indexex prior to creating them in the SQL files.