### PR TITLE
Write Unique User Hit Data to file

### DIFF
--- a/SpecialWiretap.php
+++ b/SpecialWiretap.php
@@ -307,10 +307,17 @@ class SpecialWiretap extends SpecialPage {
 
 		$rows = $this->getUniqueRows( $showUniquePageHits, "DESC" );
 
+		// This writes the Unique User-Hit data to a file named "UUHitsforWiki_<wikiID>.csv" that is accessible by browser off of the server base url.
+		$fp = fopen("/opt/htdocs/UUHitsforWiki_".str_replace("/","",str_replace("Special:Wiretap","",SpecialPage::getTitleFor('Wiretap')->getLocalURL())).".csv", 'w');
+                fwrite($fp, "Date UUHits\n" );
+		
 		foreach($rows as $row) {
 			$html .= "<tr><td>{$row['date']}</td><td>{$row['hits']}</td></tr>";
+			fwrite($fp, "{$row['date']}, {$row['hits']}\n" );
 		}
 
+                fclose($fp);
+		
 		$html .= "</table>";
 
 		$wgOut->addHTML( $html );

--- a/SpecialWiretap.php
+++ b/SpecialWiretap.php
@@ -309,7 +309,7 @@ class SpecialWiretap extends SpecialPage {
 
 		// This writes the Unique User-Hit data to a file named "UUHitsforWiki_<wikiID>.csv" that is accessible by browser off of the server base url.
 		$fp = fopen("/opt/htdocs/UUHitsforWiki_".str_replace("/","",str_replace("Special:Wiretap","",SpecialPage::getTitleFor('Wiretap')->getLocalURL())).".csv", 'w');
-                fwrite($fp, "Date UUHits\n" );
+                fwrite($fp, "Date, UUHits\n" );
 		
 		foreach($rows as $row) {
 			$html .= "<tr><td>{$row['date']}</td><td>{$row['hits']}</td></tr>";


### PR DESCRIPTION
updates public function uniqueTotals with simple fopen, fwrite, and fclose commands to write the data to a local file that is readily readable off the server base url. This allows Extension:External Data to read the data in on all wikis and generate summary sand plots showing wiki usage trends across the entire server.