### PR TITLE
Make changes for MediaWiki 1.39

### DIFF
--- a/Wiretap.body.php
+++ b/Wiretap.body.php
@@ -12,7 +12,7 @@ class Wiretap {
 	 **/
 	public static function updateTable( &$title, &$article, &$output, &$user, $request, $mediaWiki ) {
 
-		$output->enableClientCache( false );
+		$output->disableClientCache();
 		$output->addMeta( 'http:Pragma', 'no-cache' );
 
 		global $wgRequestTime, $egWiretapCurrentHit;


### PR DESCRIPTION
From https://www.mediawiki.org/wiki/Release_notes/1.38

OutputPage::enableClientCache() was deprecated, because it is universally used to do the opposite -- use OutputPage::disableClientCache() instead.